### PR TITLE
Support relative urls

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -105,5 +105,26 @@ describe('SearXNG MCP Server', () => {
         query: 'test'
       })).rejects.toThrow('All SearXNG instances failed');
     });
+
+    it('should resolve urls correctly', async() => {
+      SEARXNG_INSTANCES.splice(0, SEARXNG_INSTANCES.length);
+      SEARXNG_INSTANCES.push('https://instance1/relative/')
+
+      nock('https://instance1')
+        .post('/relative/search')
+        .reply(200, { results: [{
+            title: 'Test',
+            url: 'https://test.com',
+            content: 'Test content',
+            engine: 'test-engine'
+          }]
+        });
+
+      const result = await searchWithFallback({
+        query: 'test'
+      });
+      expect(result.results).toBeDefined();
+      expect(result.results.length).toBe(1);
+    });
   });
 }); 

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ async function searchWithFallback(params: any) {
 
   for (const instance of SEARXNG_INSTANCES) {
     try {
-      const searchUrl = new URL('/search', instance);
+      const searchUrl = new URL('./search', instance);
       const response = await fetch(searchUrl.toString(), {
         method: 'POST',
         headers: {


### PR DESCRIPTION
If you are running your SearXNG instance behind a reverse proxy using path-based routing, the path part of the url gets overwritten in the `URL` constructor with `/search`, i.e. `SEARXNG_INSTANCES=http://localhost:8080/some/path/` becomes a URL of `http://localhost:8080/search`, dropping the `/some/path/` entirely. By using a relative url in the `URL` constructor, your path is preserved, i.e. `SEARXNG_INSTANCES=http://localhost:8080/some/path/` becomes a URL of `http://localhost:8080/some/path/search`.